### PR TITLE
ci: skip tag creation if tag already exists on remote

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,13 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-        git push origin "${{ steps.version.outputs.tag }}"
+        TAG="${{ steps.version.outputs.tag }}"
+        if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
+          echo "Tag $TAG already exists, skipping tag creation"
+        else
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+        fi
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Fix release workflow crashing when tag already exists — skips git tag push if the tag is already present on remote.